### PR TITLE
10 enable self signed tls support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This module uses the [Flic Hub SDK](https://flic.io/flic-hub-sdk) to send your Flic Button events and states to the [Home Assistant REST API](https://developers.home-assistant.io/docs/api/rest).
 
-> If you have any automations running with the **flicd add-on** from [pschmitt’s repository](https://github.com/pschmitt/home-assistant-addons) they will continue to work after pairing the same Flic Button to the Flic Hub as the events sent by the module keeps the same [type and data](https://www.home-assistant.io/integrations/flic).
+> If you have any automations running with the **flicd add-on** from [pschmitt’s addon](https://github.com/pschmitt/home-assistant-addons) they will continue to work after pairing the same Flic Button to the Flic Hub as the events sent by the module keeps the same [type and data](https://www.home-assistant.io/integrations/flic).
 
 ## Set up
 
@@ -20,13 +20,16 @@ It should look something like this:
 
 Then edit the `config.js` file so the Flic Hub can connect to your Home Assistant REST API.
 
-| Param                   | Value   | Description |
-| :---------------------- | :-----: | :---------- |
-| `MIN_EVENTS_OFFSET`     | Integer | When the time elapsed between two events is less than `MIN_EVENTS_OFFSET` milliseconds, the most recent event will be ignored. Events like `double` and `hold` sometimes trigger a `single` event when you release the button |
-| `SYNC_TIME`             | Integer | Defines how often (in milliseconds) the state for all the buttons will be reported to Home Assistant |
-| `WARNING_BATTERY_LEVEL` | Integer | If battery level is below this value (in percentage), a battery warning icon will be shown |
-| `SERVER_HOST`           | String  | The URL where your Home Assistant instance is running. Example: `http://192.168.XXX.YYY:8123` |
-| `SERVER_AUTH_TOKEN`     | String  | A **Long-Lived Access Token** obtained from [your profile](https://www.home-assistant.io/docs/authentication/#your-account-profile) `http://192.168.XXX.YYY:8123/profile` |
+| Param                    | Value   | Description |
+| :----------------------- | :-----: | :---------- |
+| `MIN_EVENTS_OFFSET`      | Integer | When the time elapsed between two events is less than `MIN_EVENTS_OFFSET` milliseconds, the most recent event will be ignored. Events like `double` and `hold` sometimes trigger a `single` event when you release the button |
+| `SYNC_TIME`              | Integer | Defines how often (in milliseconds) the state for all the buttons will be reported to Home Assistant. |
+| `WARNING_BATTERY_LEVEL`  | Integer | If battery level is below this value (in percentage), a battery warning icon will be shown. |
+| `SERVER_HOST`            | String  | The URL where your Home Assistant instance is running. Example: `https://192.168.XXX.YYY:8123`. |
+| `SERVER_AUTH_TOKEN`      | String  | A **Long-Lived Access Token** obtained from [your profile](https://www.home-assistant.io/docs/authentication/#your-account-profile) `https://192.168.XXX.YYY:8123/profile`. |
+| `USE_CUSTOM_CERTIFICATE` | Boolean | Enables the use of a custom certificate for HTTPS, ideal for self signed certificates. |
+| `VERIFY_CERTIFICATE`     | Boolean | If a custom certificate is used, whether to validate the hostname in the URL against the Subject Alternative Name extension in the server's certificate. |
+| `CUSTOM_CERTIFICATES`    | String  | (From [Flic Hub Documentation](https://hubsdk.flic.io/static/documentation/#43_makerequest)) One or more certificates to trust in PEM format. Can be both end entity certificates or CA certificates. If multiple certificates, concatenate them. Extraneous whitespace is allowed. |
 
 > Be sure you have the **API** component enabled in your Home Asistant instance (enabled by default). In case you have any troubles see their [documentation](https://www.home-assistant.io/integrations/api) to know how to enable it.
 
@@ -53,7 +56,7 @@ Where the possible values for **click_type** are: `single`, `double` and `hold`.
 
 ## Flic button card
 
-It is possible to add a card to your dashboard to check **state**, **battery** and **connectivity** status for your flics
+It is possible to add a card to your dashboard to check **state**, **battery** and **connectivity** status for your flics:
 
 ![Flic Button Card](./res/FlicButtonCard.png?raw=true "Flic Button Card")
 

--- a/flic_hub_module/config.js
+++ b/flic_hub_module/config.js
@@ -3,3 +3,6 @@ exports.SYNC_TIME = 1 * 60 * 1000;
 exports.WARNING_BATTERY_LEVEL = 8;
 exports.SERVER_HOST = 'http://192.168.XXX.YYY:8123';
 exports.SERVER_AUTH_TOKEN = 'Your Long-Lived Access Token';
+exports.USE_CUSTOM_CERTIFICATE = false
+exports.VERIFY_CERTIFICATE = false
+exports.CUSTOM_CERTIFICATES = "-----BEGIN CERTIFICATE-----MIICizCCAfSgAwIBAgIUGu...8gJynKjhWy2vGoDJNx36I+-----END CERTIFICATE-----"

--- a/flic_hub_module/config.js
+++ b/flic_hub_module/config.js
@@ -1,7 +1,7 @@
 exports.MIN_EVENTS_OFFSET = 600;
 exports.SYNC_TIME = 1 * 60 * 1000;
 exports.WARNING_BATTERY_LEVEL = 8;
-exports.SERVER_HOST = 'http://192.168.XXX.YYY:8123';
+exports.SERVER_HOST = 'https://192.168.XXX.YYY:8123';
 exports.SERVER_AUTH_TOKEN = 'Your Long-Lived Access Token';
 exports.USE_CUSTOM_CERTIFICATE = false
 exports.VERIFY_CERTIFICATE = false

--- a/flic_hub_module/ha.js
+++ b/flic_hub_module/ha.js
@@ -86,6 +86,12 @@ function notifyHomeAssistant(options) {
 		'Authorization': 'Bearer ' + CFG.SERVER_AUTH_TOKEN,
 		'Content-Type': 'application/json'
 	};
+	if(CFG.USE_CUSTOM_TLS) {
+		options.customTrustStore = {
+			'certList': CFG.CUSTOM_CERTS,
+			'validateHostname': CFG.VERIFY_TLS
+		}
+	}
 	http.makeRequest(options, function (error, result) {
 		console.log("------------------------------------------");
 		console.log("Request: " + JSON.stringify(options) + "\n");

--- a/flic_hub_module/module.json
+++ b/flic_hub_module/module.json
@@ -1,6 +1,6 @@
 {
 	"name": "Flic Hub Module for Home Assistant",
-	"version": "1.2.4",
+	"version": "1.2.5",
 	"author": "Brayan Luna <blun4n@gmail.com> (https://www.blunan.com)",
 	"license": "MIT"
 }


### PR DESCRIPTION
Enable self signed tls support by using custom trust store (https://hubsdk.flic.io/static/documentation/#43_makerequest)