### PR TITLE
fix: Don't report unknown battery status to HA

### DIFF
--- a/flic_hub_module/ha.js
+++ b/flic_hub_module/ha.js
@@ -19,16 +19,15 @@ exports.sendButtonState = function(obj, state) {
 
 exports.sendButtonBatteryState = function(obj) {
 	var button = JSON.parse(JSON.stringify(obj));
-	var battery = button.batteryStatus == null ? 0 : button.batteryStatus;
 	notifyHomeAssistant({
 		'method': "POST",
 		'url': CFG.SERVER_HOST + "/api/states/sensor." + utils.getButtonName(button) + "_battery",
 		'content': JSON.stringify({
-			'state': battery,
+			'state': button.batteryStatus,
 			'attributes': {
 				'device_class': 'battery',
 				'unit_of_measurement': '%',
-				'icon': utils.getBatteryIcon(battery),
+				'icon': utils.getBatteryIcon(button.batteryStatus),
 				'friendly_name': utils.getButtonFriendlyName(button, "Battery")
 			}
 		})

--- a/flic_hub_module/main.js
+++ b/flic_hub_module/main.js
@@ -24,8 +24,11 @@ function initButton(button) {
 function syncButtons() {
 	var buttons = buttonManager.getButtons();
 	for (var i = 0; i < buttons.length; i++) {
-		ha.sendButtonBatteryState(buttons[i]);
-		ha.sendButtonConnectivityState(buttons[i]);
+		var button = buttons[i];
+		if (button.batteryStatus != null) {
+			ha.sendButtonBatteryState(button);
+		}
+		ha.sendButtonConnectivityState(button);
 	}
 }
 


### PR DESCRIPTION
It seems none of my buttons actually reported their battery status, and the sensor reporting 0 interfered with how I track things needing battery replacements so I made changed the scripts a little here to avoid it.