### PR TITLE
v1.2.6 - hotfix/Custom_HTTP_trust_store

### DIFF
--- a/flic_hub_module/ha.js
+++ b/flic_hub_module/ha.js
@@ -86,10 +86,10 @@ function notifyHomeAssistant(options) {
 		'Authorization': 'Bearer ' + CFG.SERVER_AUTH_TOKEN,
 		'Content-Type': 'application/json'
 	};
-	if(CFG.USE_CUSTOM_TLS) {
+	if(CFG.USE_CUSTOM_CERTIFICATE) {
 		options.customTrustStore = {
-			'certList': CFG.CUSTOM_CERTS,
-			'validateHostname': CFG.VERIFY_TLS
+			'certList': CFG.CUSTOM_CERTIFICATES,
+			'validateHostname': CFG.VERIFY_CERTIFICATE
 		}
 	}
 	http.makeRequest(options, function (error, result) {

--- a/flic_hub_module/module.json
+++ b/flic_hub_module/module.json
@@ -1,6 +1,6 @@
 {
 	"name": "Flic Hub Module for Home Assistant",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"author": "Brayan Luna <blun4n@gmail.com> (https://www.blunan.com)",
 	"license": "MIT"
 }


### PR DESCRIPTION
Fix config key mismatch in custom trust store lookup so the USE_CUSTOM_CERTIFICATE / CUSTOM_CERTIFICATES / VERIFY_CERTIFICATE options actually take effect.